### PR TITLE
fix: Use background threads to allow process to gracefully exit

### DIFF
--- a/LibAtem/Net/AtemClient.cs
+++ b/LibAtem/Net/AtemClient.cs
@@ -135,6 +135,7 @@ namespace LibAtem.Net
                 }
             });
             _sendThread.Name = "LibAtem.Send";
+            _sendThread.IsBackground = true;
             _sendThread.Start();
         }
 
@@ -155,6 +156,7 @@ namespace LibAtem.Net
                 }
             });
             _handleThread.Name = "LibAtem.Handle";
+            _handleThread.IsBackground = true;
             _handleThread.Start();
         }
 
@@ -213,6 +215,7 @@ namespace LibAtem.Net
                 }
             });
             thread.Name = "LibAtem.Receive";
+            thread.IsBackground = true;
             thread.Start();
         }
 


### PR DESCRIPTION
I noticed that `AtemClient`'s threads were keeping my process alive after all other threads (UI) terminated. I've marked the threads `IsBackground = true` so they don't affect the lifetime of the process.