### PR TITLE
Added netstandard2.0 target to runtime binaries.

### DIFF
--- a/LibAtem.DeviceProfile/LibAtem.DeviceProfile.csproj
+++ b/LibAtem.DeviceProfile/LibAtem.DeviceProfile.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibAtem.Discovery/LibAtem.Discovery.csproj
+++ b/LibAtem.Discovery/LibAtem.Discovery.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibAtem.State/LibAtem.State.csproj
+++ b/LibAtem.State/LibAtem.State.csproj
@@ -1,8 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+      <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\LibAtem\LibAtem.csproj" />

--- a/LibAtem.XmlState.GenerateMacroOperation/GenerateMacroOperation.cs
+++ b/LibAtem.XmlState.GenerateMacroOperation/GenerateMacroOperation.cs
@@ -307,7 +307,7 @@ namespace LibAtem.XmlState.GenerateMacroOperation
 
         private static IEnumerable<StatementSyntax> GenerateMacroOpToXml(Operation op)
         {
-            string[] nameParts = op.Classname.Split(".");
+            string[] nameParts = op.Classname.Split('.');
             string id = nameParts[nameParts.Count() - 1];
 
             var props = SyntaxFactory.SeparatedList<ExpressionSyntax>()

--- a/LibAtem.XmlState.GenerateMacroOperation/LibAtem.XmlState.GenerateMacroOperation.csproj
+++ b/LibAtem.XmlState.GenerateMacroOperation/LibAtem.XmlState.GenerateMacroOperation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject>LibAtem.XmlState.GenerateMacroOperation.GenerateMacroOperation</StartupObject>

--- a/LibAtem.XmlState/LibAtem.XmlState.csproj
+++ b/LibAtem.XmlState/LibAtem.XmlState.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,8 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="System.Xml.XmlSerializer">
-    </Reference>
+    <Reference Include="System.Xml.XmlSerializer" />
   </ItemGroup>
 
 </Project>

--- a/LibAtem/LibAtem.csproj
+++ b/LibAtem/LibAtem.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
Added netstandard2.0 target to gain project support for many earlier versions of .NET, including Framework 4.6.1+.
Actually, the netstandard2.0 would be only target of the runtime libraries, as .NET Standard 2.0 is compatible also with .NET 8+.
Tests remained on net8.0.